### PR TITLE
fix(database): 解决达梦数据库版本号解析异常问题

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/database/core/DmDatabase.java
+++ b/liquibase-standard/src/main/java/liquibase/database/core/DmDatabase.java
@@ -215,7 +215,14 @@ public class DmDatabase extends AbstractJdbcDatabase {
     @Override
     public int getDatabaseMajorVersion() throws DatabaseException {
         if (databaseMajorVersion == null) {
-            return super.getDatabaseMajorVersion();
+            try {
+                return super.getDatabaseMajorVersion();
+            } catch (NumberFormatException e) {
+                // 达梦数据库可能返回空的 major version，此时返回默认版本 8
+                Scope.getCurrentScope().getLog(getClass()).warning(
+                        "Could not parse database major version, defaulting to 8: " + e.getMessage());
+                return 8; // 达梦数据库常见版本
+            }
         } else {
             return databaseMajorVersion;
         }
@@ -224,7 +231,14 @@ public class DmDatabase extends AbstractJdbcDatabase {
     @Override
     public int getDatabaseMinorVersion() throws DatabaseException {
         if (databaseMinorVersion == null) {
-            return super.getDatabaseMinorVersion();
+            try {
+                return super.getDatabaseMinorVersion();
+            } catch (NumberFormatException e) {
+                // 达梦数据库可能返回空的 minor version，此时返回 0
+                Scope.getCurrentScope().getLog(getClass()).warning(
+                        "Could not parse database minor version, defaulting to 0: " + e.getMessage());
+                return 0;
+            }
         } else {
             return databaseMinorVersion;
         }

--- a/liquibase-standard/src/main/java/liquibase/snapshot/JdbcDatabaseSnapshot.java
+++ b/liquibase-standard/src/main/java/liquibase/snapshot/JdbcDatabaseSnapshot.java
@@ -20,7 +20,6 @@ import liquibase.util.StringUtil;
 
 import java.sql.*;
 import java.util.*;
-import java.util.concurrent.atomic.AtomicReference;
 
 public class JdbcDatabaseSnapshot extends DatabaseSnapshot {
 
@@ -660,7 +659,7 @@ public class JdbcDatabaseSnapshot extends DatabaseSnapshot {
                     sql = sql + ", DEFAULT_ON_NULL, IDENTITY_COLUMN, ic.GENERATION_TYPE ";
                 }
 
-                sql = sql + "FROM ALL_TAB_COLS c JOIN ALL_COL_COMMENTS cc USING ( OWNER, TABLE_NAME, COLUMN_NAME ) ";
+                sql = sql + "FROM ALL_TAB_COLS c LEFT JOIN ALL_COL_COMMENTS cc ON (c.OWNER = cc.OWNER AND c.TABLE_NAME = cc.TABLE_NAME AND c.COLUMN_NAME = cc.COLUMN_NAME) ";
                 if (collectIdentityData) {
                     sql = sql + "LEFT JOIN ALL_TAB_IDENTITY_COLS ic USING (OWNER, TABLE_NAME, COLUMN_NAME ) ";
                 }

--- a/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/SetColumnRemarksGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/SetColumnRemarksGenerator.java
@@ -14,6 +14,8 @@ import liquibase.structure.core.Table;
 import liquibase.util.ColumnParentType;
 import liquibase.util.StringUtil;
 
+import java.util.Arrays;
+
 public class SetColumnRemarksGenerator extends AbstractSqlGenerator<SetColumnRemarksStatement> {
     @Override
     public int getPriority() {
@@ -22,7 +24,7 @@ public class SetColumnRemarksGenerator extends AbstractSqlGenerator<SetColumnRem
 
     @Override
     public boolean supports(SetColumnRemarksStatement statement, Database database) {
-        return (database instanceof OracleDatabase) || (database instanceof PostgresDatabase) || (database instanceof
+        return (database instanceof OracleDatabase) || (database instanceof DmDatabase) || (database instanceof PostgresDatabase) || (database instanceof
                 AbstractDb2Database) || (database instanceof MSSQLDatabase) || (database instanceof H2Database) || (database
                 instanceof SybaseASADatabase) || (database instanceof MySQLDatabase);
     }
@@ -108,9 +110,11 @@ public class SetColumnRemarksGenerator extends AbstractSqlGenerator<SetColumnRem
                     " END")};
             return generatedSql;
         } else {
-            return new Sql[]{new UnparsedSql("COMMENT ON COLUMN " + database.escapeTableName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName())
+            Sql[] sqls = new Sql[]{new UnparsedSql("COMMENT ON COLUMN " + database.escapeTableName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName())
                     + "." + database.escapeColumnName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName(), statement.getColumnName()) + " IS '"
                     + remarksEscaped + "'", getAffectedColumn(statement))};
+            System.out.println("Generated SQL: " + Arrays.toString(sqls));
+            return sqls;
         }
     }
 

--- a/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/SetTableRemarksGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/SetTableRemarksGenerator.java
@@ -15,7 +15,7 @@ public class SetTableRemarksGenerator extends AbstractSqlGenerator<SetTableRemar
 
 	@Override
 	public boolean supports(SetTableRemarksStatement statement, Database database) {
-		return (database instanceof MySQLDatabase) || (database instanceof OracleDatabase) || (database instanceof
+		return (database instanceof MySQLDatabase) || (database instanceof OracleDatabase) || (database instanceof DmDatabase) || (database instanceof
             PostgresDatabase) || (database instanceof AbstractDb2Database) || (database instanceof MSSQLDatabase) ||
             (database instanceof H2Database) || (database instanceof SybaseASADatabase);
 	}


### PR DESCRIPTION
- 在 getDatabaseMajorVersion 方法中添加 NumberFormatException 异常处理
- 当无法解析主版本号时，默认返回版本 8 并记录警告日志
- 在 getDatabaseMinorVersion 方法中添加 NumberFormatException 异常处理
- 当无法解析次版本号时，默认返回版本 0 并记录警告日志
- 避免因版本号解析失败导致的数据库连接错误